### PR TITLE
updated bcftools/consensus from nf-core

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "bcftools/consensus": {
                         "branch": "master",
-                        "git_sha": "7f0ad5e597d8f3567d191d9b24098f1595f3cc70",
+                        "git_sha": "2efa3f86f20c99d23a231d631a94badde8e3501c",
                         "installed_by": [
                             "modules"
                         ]
@@ -50,7 +50,9 @@
                     "fastp": {
                         "branch": "master",
                         "git_sha": "b90b5cd93149a1b3be263d916c7234fe0708a71c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
@@ -77,7 +79,9 @@
                     "lofreq/callparallel": {
                         "branch": "master",
                         "git_sha": "94e871f884efe963381a04e173f21924c9e9aba2",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "lofreq/filter": {
                         "branch": "master",
@@ -199,17 +203,23 @@
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "92de218a329bfc9a9033116eb5f65fd270e72ba3",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfvalidation_plugin": {
                         "branch": "master",
                         "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/bcftools/consensus/environment.yml
+++ b/modules/nf-core/bcftools/consensus/environment.yml
@@ -1,7 +1,5 @@
-name: bcftools_consensus
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::bcftools=1.20

--- a/modules/nf-core/bcftools/consensus/main.nf
+++ b/modules/nf-core/bcftools/consensus/main.nf
@@ -35,4 +35,17 @@ process BCFTOOLS_CONSENSUS {
         bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
     END_VERSIONS
     """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def masking = mask ? "-m $mask" : ""
+    """
+    touch ${prefix}.fa
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/bcftools/consensus/meta.yml
+++ b/modules/nf-core/bcftools/consensus/meta.yml
@@ -12,42 +12,45 @@ tools:
       documentation: http://www.htslib.org/doc/bcftools.html
       doi: 10.1093/bioinformatics/btp352
       licence: ["MIT"]
+      identifier: biotools:bcftools
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - vcf:
-      type: file
-      description: VCF file
-      pattern: "*.{vcf}"
-  - tbi:
-      type: file
-      description: tabix index file
-      pattern: "*.{tbi}"
-  - fasta:
-      type: file
-      description: FASTA reference file
-      pattern: "*.{fasta,fa}"
-  - mask:
-      type: file
-      description: BED file used for masking
-      pattern: "*.{bed}"
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: VCF file
+        pattern: "*.{vcf}"
+    - tbi:
+        type: file
+        description: tabix index file
+        pattern: "*.{tbi}"
+    - fasta:
+        type: file
+        description: FASTA reference file
+        pattern: "*.{fasta,fa}"
+    - mask:
+        type: file
+        description: BED file used for masking
+        pattern: "*.{bed}"
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - fasta:
-      type: file
-      description: FASTA reference consensus file
-      pattern: "*.{fasta,fa}"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fa":
+          type: file
+          description: FASTA reference consensus file
+          pattern: "*.{fasta,fa}"
   - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/bcftools/consensus/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/consensus/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.fa:md5,313f4a657187fdaf293c4ed69d98c112"
+                        "test.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -18,7 +18,7 @@
                         {
                             "id": "test"
                         },
-                        "test.fa:md5,313f4a657187fdaf293c4ed69d98c112"
+                        "test.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -27,10 +27,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-08-20T13:56:14.553364445"
+        "timestamp": "2024-12-20T15:38:55.13767915"
     },
     "bcftools - test": {
         "content": [


### PR DESCRIPTION
- updated bcftools/consensus from nf-core
- bcftools/consensus contains a stub now

Vanilla pipeline stub test works:
```
nf-test test     -c my.config     --profile singularity     --tag stub tests/

🚀 nf-test 0.8.4
https://code.askimed.com/nf-test
(c) 2021 - 2024 Lukas Forer and Sebastian Schoenherr

Load [redacted]/nft-bam-0.5.0.jar
Load [redacted]/nft-vcf-1.0.7.jar
Load [redacted]/nft-utils-0.0.3.jar
Load [redacted]/nft-fasta-1.0.0.jar

Test Workflow main.nf

  Test [a1428350] 'Vanilla stub test' PASSED (21.229s)


SUCCESS: Executed 1 tests in 21.236s
```