### PR TITLE
hotfix to join only on `meta.id` in nf-core subwfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ testing*
 *.pyc
 null/
 .vscode/
+.nf-test/

--- a/modules.json
+++ b/modules.json
@@ -152,22 +152,26 @@
                     "bam_markduplicates_picard": {
                         "branch": "master",
                         "git_sha": "49f4e50534fe4b64101e62ea41d5dc43b1324358",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": ["subworkflows"],
+                        "patch": "subworkflows/nf-core/bam_markduplicates_picard/bam_markduplicates_picard.diff"
                     },
                     "bam_sort_stats_samtools": {
                         "branch": "master",
                         "git_sha": "46eca555142d6e597729fcb682adcc791796f514",
-                        "installed_by": ["fastq_align_bwa"]
+                        "installed_by": ["fastq_align_bwa"],
+                        "patch": "subworkflows/nf-core/bam_sort_stats_samtools/bam_sort_stats_samtools.diff"
                     },
                     "bam_stats_samtools": {
                         "branch": "master",
                         "git_sha": "0eacd714effe5aac1c1de26593873960b3346cab",
-                        "installed_by": ["bam_markduplicates_picard", "bam_sort_stats_samtools"]
+                        "installed_by": ["bam_markduplicates_picard", "bam_sort_stats_samtools"],
+                        "patch": "subworkflows/nf-core/bam_stats_samtools/bam_stats_samtools.diff"
                     },
                     "fastq_align_bwa": {
                         "branch": "master",
                         "git_sha": "e0ff65e1fb313677de09f5f477ae3da30ce19b7b",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": ["subworkflows"],
+                        "patch": "subworkflows/nf-core/fastq_align_bwa/fastq_align_bwa.diff"
                     },
                     "fastq_extract_kraken_krakentools": {
                         "branch": "master",

--- a/subworkflows/nf-core/bam_markduplicates_picard/bam_markduplicates_picard.diff
+++ b/subworkflows/nf-core/bam_markduplicates_picard/bam_markduplicates_picard.diff
@@ -1,0 +1,46 @@
+Changes in component 'nf-core/bam_markduplicates_picard'
+Changes in 'bam_markduplicates_picard/main.nf':
+--- subworkflows/nf-core/bam_markduplicates_picard/main.nf
++++ subworkflows/nf-core/bam_markduplicates_picard/main.nf
+@@ -9,15 +9,31 @@
+ workflow BAM_MARKDUPLICATES_PICARD {
+ 
+     take:
+-    ch_reads   // channel: [ val(meta), path(reads) ]
+-    ch_fasta // channel: [ path(fasta) ]
+-    ch_fai   // channel: [ path(fai) ]
++    ch_reads    // channel: [ val(meta), path(reads) ]
++    ch_fasta    // channel: [ path(fasta) ]
++    ch_fai      // channel: [ path(fai) ]
+ 
+     main:
+ 
+     ch_versions = Channel.empty()
+ 
+-    PICARD_MARKDUPLICATES ( ch_reads, ch_fasta, ch_fai )
++    //sort channels to maintain order across different channels
++    ch_reads_cpy = ch_reads.map {meta, reads -> return [meta.id, meta, reads]} 
++    ch_fasta_cpy = ch_fasta.map {meta, fasta -> return [meta.id, meta, fasta]}
++    ch_fai_cpy = ch_fai.map {meta, fai -> return [meta.id, meta, fai]}
++
++    ch_picard_markduplicates_input = ch_reads_cpy.join(ch_fasta_cpy).join(ch_fai_cpy)
++        .multiMap{_sample_id, meta, reads, meta2, reference, meta3, fai_index ->
++            ch_reads: [ meta, reads ]
++            ch_ref: [ meta2, reference ]
++            ch_fai_index: [ meta3, fai_index ]
++        }
++
++    PICARD_MARKDUPLICATES(
++        ch_picard_markduplicates_input.ch_reads,
++        ch_picard_markduplicates_input.ch_ref,
++        ch_picard_markduplicates_input.ch_fai_index
++    )
+     ch_versions = ch_versions.mix(PICARD_MARKDUPLICATES.out.versions.first())
+ 
+     ch_markdup = PICARD_MARKDUPLICATES.out.bam.mix(PICARD_MARKDUPLICATES.out.cram)
+
+'subworkflows/nf-core/bam_markduplicates_picard/meta.yml' is unchanged
+'subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test' is unchanged
+'subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test.snap' is unchanged
+'subworkflows/nf-core/bam_markduplicates_picard/tests/tags.yml' is unchanged
+************************************************************

--- a/subworkflows/nf-core/bam_markduplicates_picard/main.nf
+++ b/subworkflows/nf-core/bam_markduplicates_picard/main.nf
@@ -18,11 +18,15 @@ workflow BAM_MARKDUPLICATES_PICARD {
     ch_versions = Channel.empty()
 
     //sort channels to maintain order across different channels
-    ch_picard_markduplicates_input = ch_reads.join(ch_fasta).join(ch_fai)
-        .multiMap{meta, reads, reference, fai_index ->
+    ch_reads_cpy = ch_reads.map {meta, reads -> return [meta.id, meta, reads]} 
+    ch_fasta_cpy = ch_fasta.map {meta, fasta -> return [meta.id, meta, fasta]}
+    ch_fai_cpy = ch_fai.map {meta, fai -> return [meta.id, meta, fai]}
+
+    ch_picard_markduplicates_input = ch_reads_cpy.join(ch_fasta_cpy).join(ch_fai_cpy)
+        .multiMap{_sample_id, meta, reads, meta2, reference, meta3, fai_index ->
             ch_reads: [ meta, reads ]
-            ch_ref: [ meta, reference ]
-            ch_fai_index: [ meta, fai_index ]
+            ch_ref: [ meta2, reference ]
+            ch_fai_index: [ meta3, fai_index ]
         }
 
     PICARD_MARKDUPLICATES(

--- a/subworkflows/nf-core/bam_sort_stats_samtools/bam_sort_stats_samtools.diff
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/bam_sort_stats_samtools.diff
@@ -1,0 +1,562 @@
+Changes in component 'nf-core/bam_sort_stats_samtools'
+Changes in 'bam_sort_stats_samtools/main.nf':
+--- subworkflows/nf-core/bam_sort_stats_samtools/main.nf
++++ subworkflows/nf-core/bam_sort_stats_samtools/main.nf
+@@ -15,7 +15,18 @@
+ 
+     ch_versions = Channel.empty()
+ 
+-    SAMTOOLS_SORT ( ch_bam, ch_fasta )
++    //sort channels to maintain order across different channels
++    ch_bam_cpy = ch_bam.map { meta, bam -> return [meta.id, meta, bam]}
++    ch_fasta_cpy = ch_fasta.map { meta, fasta -> return [meta.id, meta, fasta]}
++
++    ch_samtools_sort_input = ch_bam_cpy.join(ch_fasta_cpy)
++        .multiMap{_sample_id, meta, bam, meta2, reference ->
++        .multiMap{meta, bam, reference ->
++            ch_bam: [ meta, bam ]
++            ch_ref: [ meta2, reference ]
++        }
++
++    SAMTOOLS_SORT ( ch_samtools_sort_input.ch_bam, ch_samtools_sort_input.ch_ref )
+     ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())
+ 
+     SAMTOOLS_INDEX ( SAMTOOLS_SORT.out.bam )
+
+'subworkflows/nf-core/bam_sort_stats_samtools/meta.yml' is unchanged
+Changes in 'bam_sort_stats_samtools/tests/main.nf.test':
+--- subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test
++++ subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test
+@@ -19,6 +19,9 @@
+     test("test_bam_sort_stats_samtools_single_end") {
+ 
+         when {
++            params {
++                outdir   = "$outputDir"
++            }
+             workflow {
+                 """
+                 input[0] = Channel.of([
+@@ -38,11 +41,9 @@
+                 { assert workflow.success},
+                 { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
+                 { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
+-                { assert snapshot(
+-                    workflow.out.flagstat,
+-                    workflow.out.idxstats,
+-                    workflow.out.stats,
+-                    workflow.out.versions).match() }
++                { assert snapshot(workflow.out.stats).match("test_bam_sort_stats_samtools_single_end_stats") },
++                { assert snapshot(workflow.out.flagstat).match("test_bam_sort_stats_samtools_single_end_flagstats") },
++                { assert snapshot(workflow.out.idxstats).match("test_bam_sort_stats_samtools_single_end_idxstats") }
+             )
+         }
+     }
+@@ -50,6 +51,9 @@
+     test("test_bam_sort_stats_samtools_paired_end") {
+ 
+         when {
++            params {
++                outdir   = "$outputDir"
++            }
+             workflow {
+                 """
+                 input[0] = Channel.of([
+@@ -69,65 +73,9 @@
+                 { assert workflow.success},
+                 { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
+                 { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
+-                { assert snapshot(
+-                    workflow.out.flagstat,
+-                    workflow.out.idxstats,
+-                    workflow.out.stats,
+-                    workflow.out.versions).match() }
+-            )
+-        }
+-    }
+-
+-    test("test_bam_sort_stats_samtools_single_end - stub") {
+-
+-        options "-stub"
+-
+-        when {
+-            workflow {
+-                """
+-                input[0] = Channel.of([
+-                    [ id:'test', single_end:false ], // meta map
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.bam', checkIfExists: true)
+-                ])
+-                input[1] = Channel.of([
+-                    [ id:'genome' ],
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+-                ])
+-                """
+-            }
+-        }
+-
+-        then {
+-            assertAll(
+-                { assert workflow.success},
+-                { assert snapshot(workflow.out).match() }
+-            )
+-        }
+-    }
+-
+-    test("test_bam_sort_stats_samtools_paired_end - stub") {
+-
+-        options "-stub"
+-
+-        when {
+-            workflow {
+-                """
+-                input[0] = Channel.of([
+-                    [ id:'test', single_end:false ], // meta map
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true)
+-                ])
+-                input[1] = Channel.of([
+-                    [ id:'genome' ],
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+-                ])
+-                """
+-            }
+-        }
+-
+-        then {
+-            assertAll(
+-                { assert workflow.success},
+-                { assert snapshot(workflow.out).match() }
++                { assert snapshot(workflow.out.stats).match("test_bam_sort_stats_samtools_paired_end_stats") },
++                { assert snapshot(workflow.out.flagstat).match("test_bam_sort_stats_samtools_paired_end_flagstats") },
++                { assert snapshot(workflow.out.idxstats).match("test_bam_sort_stats_samtools_paired_end_idxstats") }
+             )
+         }
+     }
+
+Changes in 'bam_sort_stats_samtools/tests/main.nf.test.snap':
+--- subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test.snap
++++ subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test.snap
+@@ -1,5 +1,95 @@
+ {
+-    "test_bam_sort_stats_samtools_single_end": {
++    "test_bam_sort_stats_samtools_paired_end_flagstats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.flagstat:md5,4f7ffd1e6a5e85524d443209ac97d783"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
++        },
++        "timestamp": "2023-10-22T20:25:03.687121177"
++    },
++    "test_bam_sort_stats_samtools_paired_end_idxstats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.idxstats:md5,df60a8c8d6621100d05178c93fb053a2"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
++        },
++        "timestamp": "2023-10-22T20:25:03.709648916"
++    },
++    "test_bam_sort_stats_samtools_single_end_stats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.stats:md5,d32de3b3716a11039cef2367c3c1a56e"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "23.10.1"
++        },
++        "timestamp": "2024-05-29T07:47:44.044172487"
++    },
++    "test_bam_sort_stats_samtools_paired_end_stats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.stats:md5,cca83e4fc9406fc3875b5e60055d6574"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "23.10.1"
++        },
++        "timestamp": "2024-05-29T07:47:51.426232891"
++    },
++    "test_bam_sort_stats_samtools_single_end_idxstats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.idxstats:md5,613e048487662c694aa4a2f73ca96a20"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
++        },
++        "timestamp": "2024-01-18T17:10:02.84631"
++    },
++    "test_bam_sort_stats_samtools_single_end_flagstats": {
+         "content": [
+             [
+                 [
+@@ -9,322 +99,12 @@
+                     },
+                     "test.flagstat:md5,2191911d72575a2358b08b1df64ccb53"
+                 ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.idxstats:md5,613e048487662c694aa4a2f73ca96a20"
+-                ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.stats:md5,d32de3b3716a11039cef2367c3c1a56e"
+-                ]
+-            ],
+-            [
+-                "versions.yml:md5,494b5530a1aa29fd5867cf655bebbfe1",
+-                "versions.yml:md5,9fcb0cd845bfb1f89d83201bb20649b4",
+-                "versions.yml:md5,bacc323ec4055d6f69f07a09089772d1",
+-                "versions.yml:md5,ce946e97097c6a9ccf834a3f91f6da30",
+-                "versions.yml:md5,d6c8dae685f1b7d050165fc15c7a20b5"
+             ]
+         ],
+         "meta": {
+-            "nf-test": "0.9.0",
+-            "nextflow": "24.04.3"
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
+         },
+-        "timestamp": "2024-07-22T17:02:44.34964"
+-    },
+-    "test_bam_sort_stats_samtools_paired_end": {
+-        "content": [
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.flagstat:md5,4f7ffd1e6a5e85524d443209ac97d783"
+-                ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.idxstats:md5,df60a8c8d6621100d05178c93fb053a2"
+-                ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.stats:md5,cca83e4fc9406fc3875b5e60055d6574"
+-                ]
+-            ],
+-            [
+-                "versions.yml:md5,494b5530a1aa29fd5867cf655bebbfe1",
+-                "versions.yml:md5,9fcb0cd845bfb1f89d83201bb20649b4",
+-                "versions.yml:md5,bacc323ec4055d6f69f07a09089772d1",
+-                "versions.yml:md5,ce946e97097c6a9ccf834a3f91f6da30",
+-                "versions.yml:md5,d6c8dae685f1b7d050165fc15c7a20b5"
+-            ]
+-        ],
+-        "meta": {
+-            "nf-test": "0.9.0",
+-            "nextflow": "24.04.3"
+-        },
+-        "timestamp": "2024-07-22T17:03:02.583095"
+-    },
+-    "test_bam_sort_stats_samtools_single_end - stub": {
+-        "content": [
+-            {
+-                "0": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "1": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "2": [
+-                    
+-                ],
+-                "3": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "4": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "5": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "6": [
+-                    "versions.yml:md5,494b5530a1aa29fd5867cf655bebbfe1",
+-                    "versions.yml:md5,9fcb0cd845bfb1f89d83201bb20649b4",
+-                    "versions.yml:md5,bacc323ec4055d6f69f07a09089772d1",
+-                    "versions.yml:md5,ce946e97097c6a9ccf834a3f91f6da30",
+-                    "versions.yml:md5,d6c8dae685f1b7d050165fc15c7a20b5"
+-                ],
+-                "bai": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "bam": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "csi": [
+-                    
+-                ],
+-                "flagstat": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "idxstats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "stats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "versions": [
+-                    "versions.yml:md5,494b5530a1aa29fd5867cf655bebbfe1",
+-                    "versions.yml:md5,9fcb0cd845bfb1f89d83201bb20649b4",
+-                    "versions.yml:md5,bacc323ec4055d6f69f07a09089772d1",
+-                    "versions.yml:md5,ce946e97097c6a9ccf834a3f91f6da30",
+-                    "versions.yml:md5,d6c8dae685f1b7d050165fc15c7a20b5"
+-                ]
+-            }
+-        ],
+-        "meta": {
+-            "nf-test": "0.9.0",
+-            "nextflow": "24.04.3"
+-        },
+-        "timestamp": "2024-07-22T17:03:22.328703"
+-    },
+-    "test_bam_sort_stats_samtools_paired_end - stub": {
+-        "content": [
+-            {
+-                "0": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "1": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "2": [
+-                    
+-                ],
+-                "3": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "4": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "5": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "6": [
+-                    "versions.yml:md5,494b5530a1aa29fd5867cf655bebbfe1",
+-                    "versions.yml:md5,9fcb0cd845bfb1f89d83201bb20649b4",
+-                    "versions.yml:md5,bacc323ec4055d6f69f07a09089772d1",
+-                    "versions.yml:md5,ce946e97097c6a9ccf834a3f91f6da30",
+-                    "versions.yml:md5,d6c8dae685f1b7d050165fc15c7a20b5"
+-                ],
+-                "bai": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "bam": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "csi": [
+-                    
+-                ],
+-                "flagstat": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "idxstats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "stats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "versions": [
+-                    "versions.yml:md5,494b5530a1aa29fd5867cf655bebbfe1",
+-                    "versions.yml:md5,9fcb0cd845bfb1f89d83201bb20649b4",
+-                    "versions.yml:md5,bacc323ec4055d6f69f07a09089772d1",
+-                    "versions.yml:md5,ce946e97097c6a9ccf834a3f91f6da30",
+-                    "versions.yml:md5,d6c8dae685f1b7d050165fc15c7a20b5"
+-                ]
+-            }
+-        ],
+-        "meta": {
+-            "nf-test": "0.9.0",
+-            "nextflow": "24.04.3"
+-        },
+-        "timestamp": "2024-07-22T17:03:38.833662"
++        "timestamp": "2024-01-18T17:10:02.829756"
+     }
+ }
+'subworkflows/nf-core/bam_sort_stats_samtools/tests/tags.yml' is unchanged
+************************************************************

--- a/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
@@ -21,7 +21,6 @@ workflow BAM_SORT_STATS_SAMTOOLS {
 
     ch_samtools_sort_input = ch_bam_cpy.join(ch_fasta_cpy)
         .multiMap{_sample_id, meta, bam, meta2, reference ->
-        .multiMap{meta, bam, reference ->
             ch_bam: [ meta, bam ]
             ch_ref: [ meta2, reference ]
         }

--- a/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
@@ -16,10 +16,14 @@ workflow BAM_SORT_STATS_SAMTOOLS {
     ch_versions = Channel.empty()
 
     //sort channels to maintain order across different channels
-    ch_samtools_sort_input = ch_bam.join(ch_fasta)
+    ch_bam_cpy = ch_bam.map { meta, bam -> return [meta.id, meta, bam]}
+    ch_fasta_cpy = ch_fasta.map { meta, fasta -> return [meta.id, meta, fasta]}
+
+    ch_samtools_sort_input = ch_bam_cpy.join(ch_fasta_cpy)
+        .multiMap{_sample_id, meta, bam, meta2, reference ->
         .multiMap{meta, bam, reference ->
             ch_bam: [ meta, bam ]
-            ch_ref: [ meta, reference ]
+            ch_ref: [ meta2, reference ]
         }
 
     SAMTOOLS_SORT ( ch_samtools_sort_input.ch_bam, ch_samtools_sort_input.ch_ref )

--- a/subworkflows/nf-core/bam_stats_samtools/bam_stats_samtools.diff
+++ b/subworkflows/nf-core/bam_stats_samtools/bam_stats_samtools.diff
@@ -1,0 +1,644 @@
+Changes in component 'nf-core/bam_stats_samtools'
+Changes in 'bam_stats_samtools/main.nf':
+--- subworkflows/nf-core/bam_stats_samtools/main.nf
++++ subworkflows/nf-core/bam_stats_samtools/main.nf
+@@ -14,7 +14,17 @@
+     main:
+     ch_versions = Channel.empty()
+ 
+-    SAMTOOLS_STATS ( ch_bam_bai, ch_fasta )
++    //sort channels to maintain order across different channels
++    ch_bam_bai_cpy = ch_bam_bai.map {meta, bam, bai -> return [meta.id, meta, bam, bai]} 
++    ch_fasta_cpy = ch_fasta.map {meta, fasta -> return [meta.id, meta, fasta]} 
++
++    ch_samtools_stats_input = ch_bam_bai_cpy.join(ch_fasta_cpy)
++        .multiMap{_sample_id, meta, bam, bai, meta2, reference ->
++            ch_bam_bai: [ meta, bam, bai ]
++            ch_ref: [ meta2, reference ]
++        } 
++
++    SAMTOOLS_STATS ( ch_samtools_stats_input.ch_bam_bai, ch_samtools_stats_input.ch_ref )
+     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)
+ 
+     SAMTOOLS_FLAGSTAT ( ch_bam_bai )
+
+'subworkflows/nf-core/bam_stats_samtools/meta.yml' is unchanged
+Changes in 'bam_stats_samtools/tests/main.nf.test':
+--- subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test
++++ subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test
+@@ -15,6 +15,9 @@
+     test("test_bam_stats_samtools_single_end") {
+ 
+         when {
++            params {
++                outdir   = "$outputDir"
++            }
+             workflow {
+                 """
+                 input[0] = Channel.of([
+@@ -33,11 +36,9 @@
+         then {
+             assertAll(
+                 { assert workflow.success},
+-                { assert snapshot(
+-                    workflow.out.flagstat,
+-                    workflow.out.idxstats,
+-                    workflow.out.stats,
+-                    workflow.out.versions).match() }
++                { assert snapshot(workflow.out.stats).match("test_bam_stats_samtools_single_end_stats") },
++                { assert snapshot(workflow.out.flagstat).match("test_bam_stats_samtools_single_end_flagstats") },
++                { assert snapshot(workflow.out.idxstats).match("test_bam_stats_samtools_single_end_idxstats") }
+             )
+         }
+     }
+@@ -45,6 +46,9 @@
+     test("test_bam_stats_samtools_paired_end") {
+ 
+         when {
++            params {
++                outdir   = "$outputDir"
++            }
+             workflow {
+                 """
+                 input[0] = Channel.of([
+@@ -63,11 +67,9 @@
+         then {
+             assertAll(
+                 { assert workflow.success },
+-                { assert snapshot(
+-                    workflow.out.flagstat,
+-                    workflow.out.idxstats,
+-                    workflow.out.stats,
+-                    workflow.out.versions).match() }
++                { assert snapshot(workflow.out.stats).match("test_bam_stats_samtools_paired_end_stats") },
++                { assert snapshot(workflow.out.flagstat).match("test_bam_stats_samtools_paired_end_flagstats") },
++                { assert snapshot(workflow.out.idxstats).match("test_bam_stats_samtools_paired_end_idxstats") }
+             )
+         }
+     }
+@@ -75,6 +77,9 @@
+     test("test_bam_stats_samtools_paired_end_cram") {
+ 
+         when {
++            params {
++                outdir   = "$outputDir"
++            }
+             workflow {
+                 """
+                 input[0] = Channel.of([
+@@ -93,96 +98,11 @@
+         then {
+             assertAll(
+                 { assert workflow.success},
+-                { assert snapshot(
+-                    workflow.out.flagstat,
+-                    workflow.out.idxstats,
+-                    workflow.out.stats,
+-                    workflow.out.versions).match() }
++                { assert snapshot(workflow.out.stats).match("test_bam_stats_samtools_paired_end_cram_stats") },
++                { assert snapshot(workflow.out.flagstat).match("test_bam_stats_samtools_paired_end_cram_flagstats") },
++                { assert snapshot(workflow.out.idxstats).match("test_bam_stats_samtools_paired_end_cram_idxstats") }
+             )
+         }
+     }
+ 
+-    test ("test_bam_stats_samtools_single_end - stub") {
+-
+-        options "-stub"
+-
+-        when {
+-            workflow {
+-                """
+-                input[0] = Channel.of([
+-                    [ id:'test', single_end:true ], // meta map
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true),
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam.bai', checkIfExists: true)
+-                ])
+-                input[1] = Channel.of([
+-                    [ id:'genome' ],
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+-                ])
+-                """
+-            }
+-        }
+-
+-        then {
+-            assertAll(
+-                { assert workflow.success},
+-                { assert snapshot(workflow.out).match() }
+-            )
+-        }
+-    }
+-
+-    test("test_bam_stats_samtools_paired_end - stub") {
+-
+-        options "-stub"
+-
+-        when {
+-            workflow {
+-                """
+-                input[0] = Channel.of([
+-                    [ id:'test', single_end:true ], // meta map
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+-                ])
+-                input[1] = Channel.of([
+-                    [ id:'genome' ],
+-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+-                ])
+-                """
+-            }
+-        }
+-
+-        then {
+-            assertAll(
+-                { assert workflow.success },
+-                { assert snapshot(workflow.out).match() }
+-            )
+-        }
+-    }
+-
+-    test("test_bam_stats_samtools_paired_end_cram - stub") {
+-
+-        options "-stub"
+-
+-        when {
+-            workflow {
+-                """
+-                input[0] = Channel.of([
+-                    [ id:'test', single_end:false ], // meta map
+-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true)
+-                ])
+-                input[1] = Channel.of([
+-                    [ id:'genome' ],
+-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+-                ])
+-                """
+-            }
+-        }
+-
+-        then {
+-            assertAll(
+-                { assert workflow.success},
+-                { assert snapshot(workflow.out).match() }
+-            )
+-        }
+-    }
+ }
+
+Changes in 'bam_stats_samtools/tests/main.nf.test.snap':
+--- subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test.snap
++++ subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test.snap
+@@ -1,230 +1,59 @@
+ {
+-    "test_bam_stats_samtools_paired_end - stub": {
++    "test_bam_stats_samtools_paired_end_cram_flagstats": {
+         "content": [
+-            {
+-                "0": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "1": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "2": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "3": [
+-                    "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                    "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                    "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
+-                ],
+-                "flagstat": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "idxstats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "stats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "versions": [
+-                    "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                    "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                    "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.flagstat:md5,a53f3d26e2e9851f7d528442bbfe9781"
+                 ]
+-            }
++            ]
+         ],
+         "meta": {
+             "nf-test": "0.8.4",
+-            "nextflow": "24.04.2"
++            "nextflow": "24.01.0"
+         },
+-        "timestamp": "2024-07-03T12:20:06.699297"
++        "timestamp": "2023-11-06T09:31:26.194017574"
+     },
+-    "test_bam_stats_samtools_single_end - stub": {
++    "test_bam_stats_samtools_paired_end_stats": {
+         "content": [
+-            {
+-                "0": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "1": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "2": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "3": [
+-                    "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                    "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                    "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
+-                ],
+-                "flagstat": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "idxstats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "stats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": true
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "versions": [
+-                    "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                    "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                    "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": true
++                    },
++                    "test.stats:md5,7afd486ad6abb9a2a3dac90c99e1d87b"
+                 ]
+-            }
++            ]
+         ],
+         "meta": {
+             "nf-test": "0.8.4",
+-            "nextflow": "24.04.2"
++            "nextflow": "23.10.1"
+         },
+-        "timestamp": "2024-07-03T12:19:57.708621"
++        "timestamp": "2024-05-29T07:46:05.502831991"
+     },
+-    "test_bam_stats_samtools_paired_end_cram - stub": {
++    "test_bam_stats_samtools_paired_end_flagstats": {
+         "content": [
+-            {
+-                "0": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "1": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "2": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "3": [
+-                    "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                    "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                    "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
+-                ],
+-                "flagstat": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.flagstat:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "idxstats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "stats": [
+-                    [
+-                        {
+-                            "id": "test",
+-                            "single_end": false
+-                        },
+-                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+-                    ]
+-                ],
+-                "versions": [
+-                    "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                    "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                    "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": true
++                    },
++                    "test.flagstat:md5,4f7ffd1e6a5e85524d443209ac97d783"
+                 ]
+-            }
++            ]
+         ],
+         "meta": {
+             "nf-test": "0.8.4",
+-            "nextflow": "24.04.2"
++            "nextflow": "24.01.0"
+         },
+-        "timestamp": "2024-07-03T12:20:17.051493"
++        "timestamp": "2024-01-18T17:17:27.717482"
+     },
+-    "test_bam_stats_samtools_single_end": {
++    "test_bam_stats_samtools_single_end_flagstats": {
+         "content": [
+             [
+                 [
+@@ -234,7 +63,70 @@
+                     },
+                     "test.flagstat:md5,2191911d72575a2358b08b1df64ccb53"
+                 ]
+-            ],
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
++        },
++        "timestamp": "2023-11-06T09:26:10.340046381"
++    },
++    "test_bam_stats_samtools_paired_end_cram_idxstats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": false
++                    },
++                    "test.idxstats:md5,e179601fa7b8ebce81ac3765206f6c15"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
++        },
++        "timestamp": "2023-11-06T09:31:26.207052003"
++    },
++    "test_bam_stats_samtools_single_end_stats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": true
++                    },
++                    "test.stats:md5,4a0c429c661d6aa0b60acb9309da642d"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "23.10.1"
++        },
++        "timestamp": "2024-05-29T07:45:59.612412212"
++    },
++    "test_bam_stats_samtools_paired_end_idxstats": {
++        "content": [
++            [
++                [
++                    {
++                        "id": "test",
++                        "single_end": true
++                    },
++                    "test.idxstats:md5,df60a8c8d6621100d05178c93fb053a2"
++                ]
++            ]
++        ],
++        "meta": {
++            "nf-test": "0.8.4",
++            "nextflow": "24.01.0"
++        },
++        "timestamp": "2024-01-18T17:17:27.726719"
++    },
++    "test_bam_stats_samtools_single_end_idxstats": {
++        "content": [
+             [
+                 [
+                     {
+@@ -243,89 +135,16 @@
+                     },
+                     "test.idxstats:md5,613e048487662c694aa4a2f73ca96a20"
+                 ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": true
+-                    },
+-                    "test.stats:md5,4a0c429c661d6aa0b60acb9309da642d"
+-                ]
+-            ],
+-            [
+-                "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
+             ]
+         ],
+         "meta": {
+             "nf-test": "0.8.4",
+-            "nextflow": "24.04.2"
++            "nextflow": "24.01.0"
+         },
+-        "timestamp": "2024-07-03T12:19:25.801394"
++        "timestamp": "2023-11-06T09:26:10.349439801"
+     },
+-    "test_bam_stats_samtools_paired_end": {
++    "test_bam_stats_samtools_paired_end_cram_stats": {
+         "content": [
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": true
+-                    },
+-                    "test.flagstat:md5,4f7ffd1e6a5e85524d443209ac97d783"
+-                ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": true
+-                    },
+-                    "test.idxstats:md5,df60a8c8d6621100d05178c93fb053a2"
+-                ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": true
+-                    },
+-                    "test.stats:md5,7afd486ad6abb9a2a3dac90c99e1d87b"
+-                ]
+-            ],
+-            [
+-                "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
+-            ]
+-        ],
+-        "meta": {
+-            "nf-test": "0.8.4",
+-            "nextflow": "24.04.2"
+-        },
+-        "timestamp": "2024-07-03T12:19:36.158768"
+-    },
+-    "test_bam_stats_samtools_paired_end_cram": {
+-        "content": [
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.flagstat:md5,a53f3d26e2e9851f7d528442bbfe9781"
+-                ]
+-            ],
+-            [
+-                [
+-                    {
+-                        "id": "test",
+-                        "single_end": false
+-                    },
+-                    "test.idxstats:md5,e179601fa7b8ebce81ac3765206f6c15"
+-                ]
+-            ],
+             [
+                 [
+                     {
+@@ -334,17 +153,12 @@
+                     },
+                     "test.stats:md5,16b59a1f2c99d9fe30f711adc3ebe32d"
+                 ]
+-            ],
+-            [
+-                "versions.yml:md5,3c485730f712b115bcdc235e7294133b",
+-                "versions.yml:md5,90f593a26a2d53e0f0345df7888f448e",
+-                "versions.yml:md5,9ae003814e63a0907d52eec64d5d3ca3"
+             ]
+         ],
+         "meta": {
+             "nf-test": "0.8.4",
+-            "nextflow": "24.04.2"
++            "nextflow": "23.10.1"
+         },
+-        "timestamp": "2024-07-03T12:19:46.625907"
++        "timestamp": "2024-05-29T07:46:11.96999343"
+     }
+ }
+'subworkflows/nf-core/bam_stats_samtools/tests/tags.yml' is unchanged
+************************************************************

--- a/subworkflows/nf-core/fastq_align_bwa/fastq_align_bwa.diff
+++ b/subworkflows/nf-core/fastq_align_bwa/fastq_align_bwa.diff
@@ -1,0 +1,52 @@
+Changes in component 'nf-core/fastq_align_bwa'
+Changes in 'fastq_align_bwa/main.nf':
+--- subworkflows/nf-core/fastq_align_bwa/main.nf
++++ subworkflows/nf-core/fastq_align_bwa/main.nf
+@@ -15,18 +15,33 @@
+     main:
+     ch_versions = Channel.empty()
+ 
++    //sort channels to maintain order across different channels
++    ch_reads_cpy = ch_reads.map { meta, reads -> return [meta.id, meta, reads]}
++    ch_fasta_cpy = ch_fasta.map { meta, fasta -> return [meta.id, meta, fasta]}
++    ch_index_cpy = ch_index.map { meta, index -> return [meta.id, meta, index]}
++
++    ch_bwa_mem_input = ch_reads_cpy.join(ch_fasta_cpy).join(ch_index_cpy)
++        .multiMap{_sample_id, meta, reads, meta2, reference, meta3, bwa_index ->
++            ch_reads: [ meta, reads ]
++            ch_ref: [ meta2, reference ]
++            ch_bwa_index: [ meta3, bwa_index ]
++        }
++
+     //
+     // Map reads with BWA
+     //
+-
+-    BWA_MEM ( ch_reads, ch_index, ch_fasta, val_sort_bam )
++    BWA_MEM(
++        ch_bwa_mem_input.ch_reads,
++        ch_bwa_mem_input.ch_bwa_index,
++        ch_bwa_mem_input.ch_ref,
++        val_sort_bam
++    )
+     ch_versions = ch_versions.mix(BWA_MEM.out.versions.first())
+ 
+-    //
+-    // Sort, index BAM file and run samtools stats, flagstat and idxstats
+-    //
+-
+-    BAM_SORT_STATS_SAMTOOLS ( BWA_MEM.out.bam, ch_fasta )
++    BAM_SORT_STATS_SAMTOOLS(
++        BWA_MEM.out.bam,
++        ch_fasta
++    )
+     ch_versions = ch_versions.mix(BAM_SORT_STATS_SAMTOOLS.out.versions)
+ 
+     emit:
+
+'subworkflows/nf-core/fastq_align_bwa/meta.yml' is unchanged
+'subworkflows/nf-core/fastq_align_bwa/tests/main.nf.test' is unchanged
+'subworkflows/nf-core/fastq_align_bwa/tests/main.nf.test.snap' is unchanged
+'subworkflows/nf-core/fastq_align_bwa/tests/nextflow.config' is unchanged
+'subworkflows/nf-core/fastq_align_bwa/tests/tags.yml' is unchanged
+************************************************************

--- a/subworkflows/nf-core/fastq_align_bwa/main.nf
+++ b/subworkflows/nf-core/fastq_align_bwa/main.nf
@@ -16,11 +16,15 @@ workflow FASTQ_ALIGN_BWA {
     ch_versions = Channel.empty()
 
     //sort channels to maintain order across different channels
-    ch_bwa_mem_input = ch_reads.join(ch_fasta).join(ch_index)
-        .multiMap{meta, reads, reference, bwa_index ->
+    ch_reads_cpy = ch_reads.map { meta, reads -> return [meta.id, meta, reads]}
+    ch_fasta_cpy = ch_fasta.map { meta, fasta -> return [meta.id, meta, fasta]}
+    ch_index_cpy = ch_index.map { meta, index -> return [meta.id, meta, index]}
+
+    ch_bwa_mem_input = ch_reads_cpy.join(ch_fasta_cpy).join(ch_index_cpy)
+        .multiMap{_sample_id, meta, reads, meta2, reference, meta3, bwa_index ->
             ch_reads: [ meta, reads ]
-            ch_ref: [ meta, reference ]
-            ch_bwa_index: [ meta, bwa_index ]
+            ch_ref: [ meta2, reference ]
+            ch_bwa_index: [ meta3, bwa_index ]
         }
 
     //


### PR DESCRIPTION
- most of the nf-core subworkflows can handle only one reference
  - for multiple references (or segments), the input must be joined and `multiMap`ed correctly
  - the joining needs to happen solely on the `meta.id`, because other values might differ for the different input channels
- added a patch file with `nf-core subworkflows patch `