### PR TITLE
version bump nft-utils@0.0.5

### DIFF
--- a/nf-test.config
+++ b/nf-test.config
@@ -22,7 +22,7 @@ config {
 
     // load the necessary plugins
     plugins {
-        load "nft-utils@0.0.4"
+        load "nft-utils@0.0.5"
         load "nft-csv@0.1.0"
         load "nft-fasta@1.0.0"
         load "nft-bam@0.6.0"


### PR DESCRIPTION
### This version bump is supposed to stabilize the snapshot ordering problem. Locally (singularity) it produced the same snapshot as on github (docker)


```bash
(omnifluss)$ nf-test test -c /<foo/<bar>/nf-test_${USER}.config  --profile singularity,INV_test_default  --tag ena_full  /<pathTo>/omnifluss/tests/

🚀 nf-test 0.9.2
https://www.nf-test.com
(c) 2021 - 2024 Lukas Forer and Sebastian Schoenherr

Load /<local>/<path>/<to>/nft-bam-0.3.0.jar
Load /<local>/<path>/<to>/nft-vcf-1.0.7.jar
Load /<local>/<path>/<to>/nft-utils-0.0.5.jar
Load /<local>/<path>/<to>/nft-fasta-1.0.0.jar
Load /<local>/<path>/<to>/nft-csv-0.1.0.jar

Test Workflow main.nf

  Test [a86c61d7] '-profile INV_test_default' PASSED (364.228s)

SUCCESS: Executed 1 tests in 364.237s
```