### PR TITLE
remove --include-parents

### DIFF
--- a/conf/pathogens/INV_illumina.config
+++ b/conf/pathogens/INV_illumina.config
@@ -73,7 +73,7 @@ process {
     }
 
     withName: 'KRAKENTOOLS_EXTRACTKRAKENREADS' {
-        ext.args = '--include-parents --fastq-output'
+        ext.args = '--fastq-output'
     }
 
     withName: 'BCFTOOLS_FILTER' {


### PR DESCRIPTION
to be in line with flupipe, remove --include-parents  -> only exact tax ID matches are extracted