### PR TITLE
added empty channel for initialization

### DIFF
--- a/subworkflows/local/fastq_map_all/main.nf
+++ b/subworkflows/local/fastq_map_all/main.nf
@@ -12,9 +12,10 @@ workflow FASTQ_MAP_ALL {
     ch_fai_index    // channel: [ val(meta), index ]
 
     main:
-    ch_bam              = Channel.empty()
-    ch_bai              = Channel.empty()
-    ch_versions         = Channel.empty()
+    ch_bam                    = Channel.empty()
+    ch_bai                    = Channel.empty()
+    ch_versions               = Channel.empty()
+    ch_markduplicates_metrics = Channel.empty()
     //for multiqc
     ch_multiqc_files    = Channel.empty()
 


### PR DESCRIPTION
 - workflow would fail if `picard_remove_duplicates` is not activated
 - failing stub test has nothing to do with the change and will be fixed in an other PR (https://github.com/rki-mf1/omnifluss/pull/137)