### PR TITLE
 remove --include-parents

### DIFF
--- a/conf/pathogens/INV_illumina.config
+++ b/conf/pathogens/INV_illumina.config
@@ -73,7 +73,7 @@ process {
     }
 
     withName: 'KRAKENTOOLS_EXTRACTKRAKENREADS' {
-        ext.args = '--include-parents --fastq-output'
+        ext.args = '--fastq-output'
     }
 
     withName: 'BCFTOOLS_FILTER' {


### PR DESCRIPTION
to be in line with flupipe, remove --include-parents -> only exact tax ID matches are extracted

---

- `skip_taxonomic_filtering` is false for the default CI tests
  - -> CI tests are not triggered
- all tests for the local module with in-house data pass
  - no changes expected because there are no other reads that are classified between the root and orthomyxo in the data -> en/disabling `--include-parents` make no difference

```
nf-test test --profile=singularity,INV_illumina,rki_slurm -c nf-test.config fastq_taxonomic_filtering_all.nf.test

🚀 nf-test 0.9.2
https://www.nf-test.com
(c) 2021 - 2024 Lukas Forer and Sebastian Schoenherr

Load nft-bam-0.3.0.jar
Load nft-vcf-1.0.7.jar
Load nft-utils-0.0.4.jar
Load nft-fasta-1.0.0.jar

Test Workflow FASTQ_TAXONOMIC_FILTERING_ALL

  Test [f2e34e3f] 'Test AS-33023' PASSED (302.684s)
  Test [edaecfdb] 'Test AS-33037' PASSED (224.663s)
  Test [5b5929e2] 'Test AS-32511' PASSED (216.725s)


SUCCESS: Executed 3 tests in 744.778s
```