### PR TITLE
reimplemented the filtering function

### DIFF
--- a/subworkflows/local/fastq_taxonomic_filtering_all/main.nf
+++ b/subworkflows/local/fastq_taxonomic_filtering_all/main.nf
@@ -30,7 +30,7 @@ workflow FASTQ_TAXONOMIC_FILTERING_ALL {
 
         // filter empty files
         def isFastqEmptyFunction = branchCriteria {_meta, reads ->
-            boolean isEmpty = (_meta.single_end) ? FileCheck.isFileEmpty(reads.toFile()) : FileCheck.isFileEmpty(reads[0].toFile()) && FileCheck.isFileEmpty(reads[1].toFile())
+            boolean isEmpty = (_meta.single_end) ? file(reads).countFastq() == 0: file(reads[0]).countFastq() == 0  && file(reads[1]).countFastq() == 0
             empty: isEmpty
             nonempty: !isEmpty
         }


### PR DESCRIPTION
* tested it with 3 routine examples that were causing issues
* solves the errors from extract kraken reads as well as the ones from KMA
* we can discuss if we stick with this approach or switch to a separate process (due to the overhead of the `countFastq()`-function)